### PR TITLE
Virtual Machine support

### DIFF
--- a/src/powerjoular.adb
+++ b/src/powerjoular.adb
@@ -28,6 +28,7 @@ with OS_Utils; use OS_Utils;
 with Nvidia_SMI; use Nvidia_SMI;
 with Raspberry_Pi_CPU_Formula; use Raspberry_Pi_CPU_Formula;
 with CPU_STAT_App; use CPU_STAT_App;
+with Virtual_Machine; use Virtual_Machine;
 
 procedure Powerjoular is
     -- Power variables
@@ -77,9 +78,19 @@ procedure Powerjoular is
     -- Platform name
     Platform_Name : String := Get_Platform_Name;
 
-    -- CSV filenames
-    CSV_Filename : Unbounded_String; -- CSV filename for entire CPU power data
-    PID_Or_App_CSV_Filename : Unbounded_String; -- CSV filename for monitored PID or application CPU power data
+   -- CSV filenames
+   CSV_Filename                  :
+      Unbounded_String; -- CSV filename for entire CPU power data
+   PID_Or_App_CSV_Filename       :
+      Unbounded_String; -- CSV filename for monitored PID or application CPU power data
+   VM_File_Name                  : Unbounded_String;
+   VM_Power_Format               : Unbounded_String;
+   Read_File_Power_Joular_Format : Boolean := False;
+   Read_File_Single_Cell_Format  : Boolean := False;
+   Monitor_VM                    : Boolean := False;
+   VM_Consumption                : Long_Float   := 0.0;
+   Last_CPU_Power                : Float;
+   Headers                       : Unbounded_String;
 
     -- Settings
     Show_Terminal : Boolean := False; -- Show power data on terminal
@@ -116,36 +127,43 @@ begin
 
     -- Loop over command line options
     loop
-        case Getopt ("h v t d f: p: a: o: u l") is
-        when 'h' => -- Show help
-            Show_Help;
-            return;
-        when 'v' => -- Show help
-            Show_Version;
-            return;
-        when 't' => -- Show power data on terminal
-            Show_Terminal := True;
-        when 'd' => -- Show debug info on terminal
-            Show_Debug := True; 
-        when 'p' => -- Monitor a particular PID
-            -- PID_Number := Integer'Value (Parameter);
-            CPU_PID_Monitor.PID_Number := Integer'Value (Parameter);
-            Monitor_PID := True;
-        when 'a' => -- Monitor a particular application by its name
-            CPU_App_Monitor.App_Name := To_Unbounded_String (Parameter);
-            Monitor_App := True;
-        when 'f' => -- Specifiy a filename for CSV file (append data)
-            CSV_Filename := To_Unbounded_String (Parameter);
-            Print_File := True;
-        when 'o' => -- Specifiy a filename for CSV file (overwrite data)
-            CSV_Filename := To_Unbounded_String (Parameter);
-            Print_File := True;
-            Overwrite_Data := True;
-        when 'l' => -- Use linear regression model instead of polynomial models
-            Algorithm_Name := To_Unbounded_String ("linear");
-        when others =>
-            exit;
-        end case;
+      case Getopt ("h v t d f: p: a: o: u l m: s:") is
+          when 'h' => -- Show help
+              Show_Help;
+              return;
+          when 'v' => -- Show help
+              Show_Version;
+              return;
+          when 't' => -- Show power data on terminal
+              Show_Terminal := True;
+          when 'd' => -- Show debug info on terminal
+              Show_Debug := True;
+          when 'p' => -- Monitor a particular PID
+              -- PID_Number := Integer'Value (Parameter);
+              CPU_PID_Monitor.PID_Number := Integer'Value (Parameter);
+              Monitor_PID                := True;
+          when 'a' => -- Monitor a particular application by its name
+              CPU_App_Monitor.App_Name :=
+                 To_Unbounded_String (Parameter);
+              Monitor_App              := True;
+          when 'f' => -- Specifiy a filename for CSV file (append data)
+              CSV_Filename := To_Unbounded_String (Parameter);
+              Print_File   := True;
+          when 'o' => -- Specifiy a filename for CSV file (overwrite data)
+              CSV_Filename   := To_Unbounded_String (Parameter);
+              Print_File     := True;
+              Overwrite_Data := True;
+          when 'l' => -- Use linear regression model instead of polynomial models
+              Algorithm_Name := To_Unbounded_String ("linear");
+          when 'm' => -- Specify a filename for CSV file to be read
+              VM_File_Name := To_Unbounded_String (Parameter);
+              Monitor_VM := True;
+          when 's' => -- Specify a filename for CSV file to be read
+              VM_Power_Format := To_Unbounded_String (Parameter);
+              Monitor_VM := True;
+          when others =>
+              exit;
+      end case;
     end loop;
 
     if (Argument_Count = 0) then
@@ -258,35 +276,51 @@ begin
         -- Calculate entire CPU utilization
         CPU_Utilization := (Long_Float (CPU_CCI_After.cbusy) - Long_Float (CPU_CCI_Before.cbusy)) / (Long_Float (CPU_CCI_After.ctotal) - Long_Float (CPU_CCI_Before.ctotal));
 
-        if Check_Raspberry_Pi_Supported_System (Platform_Name) then
-            -- Calculate power consumption for Raspberry
-            CPU_Power := Calculate_CPU_Power (CPU_Utilization, Platform_Name, To_String (Algorithm_Name));
-            Total_Power := CPU_Power;
-        end if;
+        --Ajouter Test VM
+      if Monitor_VM then
+        --Put_Line ("VM Consumption : " & Float'Image(Calculate_VM_Consumption(VM_File_Name, VM_Power_Format)));
+        CPU_Power := Long_Float(Calculate_VM_Consumption(VM_File_Name, VM_Power_Format));
+        --CPU Power = Calculate
+      else
+          if Check_Raspberry_Pi_Supported_System (Platform_Name) then
+              -- Calculate power consumption for Raspberry
+              CPU_Power   :=
+                 Calculate_CPU_Power
+                    (CPU_Utilization, Platform_Name,
+                     To_String (Algorithm_Name));
+              Total_Power := CPU_Power;
+          end if;
 
-        if Check_Intel_Supported_System (Platform_Name) then
-            -- Calculate Intel RAPL energy consumption
-            RAPL_Energy := RAPL_After.total_energy - RAPL_Before.total_energy;
+          if Check_Intel_Supported_System (Platform_Name) then
+              -- Calculate Intel RAPL energy consumption
+              RAPL_Energy :=
+                 RAPL_After.total_energy - RAPL_Before.total_energy;
 
-            if RAPL_Before.total_energy > RAPL_After.total_energy then
-                -- energy has wrapped
-                if RAPL_Before.psys_supported then
-                    RAPL_Energy := RAPL_Energy + RAPL_Before.psys_max_energy_range;
-                elsif RAPL_Before.Pkg_Supported then
-                    RAPL_Energy := RAPL_Energy + RAPL_Before.pkg_max_energy_range;
-                end if;
-            end if;
+              if RAPL_Before.total_energy > RAPL_After.total_energy then
+                  -- energy has wrapped
+                  if RAPL_Before.psys_supported then
+                      RAPL_Energy :=
+                         RAPL_Energy + RAPL_Before.psys_max_energy_range;
+                  elsif RAPL_Before.pkg_supported then
+                      RAPL_Energy :=
+                         RAPL_Energy + RAPL_Before.pkg_max_energy_range;
+                  end if;
+              end if;
 
-            if RAPL_Before.Pkg_Supported and RAPL_Before.Dram_supported then
-                if RAPL_Before.dram > RAPL_After.dram then
-                    -- dram has wrapped
-                    RAPL_Energy := RAPL_Energy + RAPL_Before.dram_max_energy_range;
-                end if;
-            end if;
+              if RAPL_Before.pkg_supported and RAPL_Before.dram_supported
+              then
+                  if RAPL_Before.dram > RAPL_After.dram then
+                      -- dram has wrapped
+                      RAPL_Energy :=
+                         RAPL_Energy + RAPL_Before.dram_max_energy_range;
+                  end if;
+              end if;
 
-            CPU_Power := RAPL_Energy;
-            Total_Power := CPU_Power;
-        end if;
+              CPU_Power   := RAPL_Energy;
+              Total_Power := CPU_Power;
+          end if;
+
+      end if;
 
         if Nvidia_Supported then
             -- Calculate GPU power consumption

--- a/src/powerjoular.adb
+++ b/src/powerjoular.adb
@@ -85,12 +85,7 @@ procedure Powerjoular is
       Unbounded_String; -- CSV filename for monitored PID or application CPU power data
    VM_File_Name                  : Unbounded_String;
    VM_Power_Format               : Unbounded_String;
-   Read_File_Power_Joular_Format : Boolean := False;
-   Read_File_Single_Cell_Format  : Boolean := False;
    Monitor_VM                    : Boolean := False;
-   VM_Consumption                : Long_Float   := 0.0;
-   Last_CPU_Power                : Float;
-   Headers                       : Unbounded_String;
 
     -- Settings
     Show_Terminal : Boolean := False; -- Show power data on terminal
@@ -155,10 +150,10 @@ begin
               Overwrite_Data := True;
           when 'l' => -- Use linear regression model instead of polynomial models
               Algorithm_Name := To_Unbounded_String ("linear");
-          when 'm' => -- Specify a filename for CSV file to be read
+          when 'm' => -- Specify a filename for a file to be read
               VM_File_Name := To_Unbounded_String (Parameter);
               Monitor_VM := True;
-          when 's' => -- Specify a filename for CSV file to be read
+          when 's' => -- Specify a data format for the provided file
               VM_Power_Format := To_Unbounded_String (Parameter);
               Monitor_VM := True;
           when others =>
@@ -276,11 +271,10 @@ begin
         -- Calculate entire CPU utilization
         CPU_Utilization := (Long_Float (CPU_CCI_After.cbusy) - Long_Float (CPU_CCI_Before.cbusy)) / (Long_Float (CPU_CCI_After.ctotal) - Long_Float (CPU_CCI_Before.ctotal));
 
-        --Ajouter Test VM
+        --Calculate VM consumption
       if Monitor_VM then
-        --Put_Line ("VM Consumption : " & Float'Image(Calculate_VM_Consumption(VM_File_Name, VM_Power_Format)));
-        CPU_Power := Long_Float(Calculate_VM_Consumption(VM_File_Name, VM_Power_Format));
-        --CPU Power = Calculate
+        CPU_Power := Read_VM_Power(VM_File_Name, VM_Power_Format);
+        Total_Power := CPU_Power;
       else
           if Check_Raspberry_Pi_Supported_System (Platform_Name) then
               -- Calculate power consumption for Raspberry

--- a/src/virtual_machine.adb
+++ b/src/virtual_machine.adb
@@ -43,8 +43,7 @@ package body Virtual_Machine is
 
            return Value;
        else
-           Ada.Text_IO.Put_Line ("File is empty or first line is blank");
-           OS_Exit (1);
+           return 0.0;
        end if;
    exception
        when others =>

--- a/src/virtual_machine.adb
+++ b/src/virtual_machine.adb
@@ -12,50 +12,46 @@ with Ada.Exceptions;                use Ada.Exceptions;
 
 package body Virtual_Machine is
 
-    --Read the exported data in PowerJoular format
-    function Read_File_PowerJoular_Format
-       (File_Path : String) return Long_Float
-    is
-        F     : File_Type;
-        Line  : Unbounded_String;
-        Last  : Unbounded_String := To_Unbounded_String ("");
-        Subs  : String_Split.Slice_Set;
-        Seps  : constant String  := ",";
-        Value : Long_Float;
-    begin
-        -- Opens the file in read mode
-        Open (F, In_File, File_Path);
+   --Read the exported data in PowerJoular format
+   function Read_File_PowerJoular_Format
+      (File_Path : String) return Long_Float
+   is
+       F     : File_Type;
+       Line  : Unbounded_String;
+       Subs  : String_Split.Slice_Set;
+       Seps  : constant String := ",";
+       Value : Long_Float;
+   begin
+       -- Opens the file in read mode
+       Open (F, In_File, File_Path);
 
-        -- Read all lines to the end of the file to get the last one
-        while not End_Of_File (F) loop
-            Line := Get_Line (F);
-            if Line /= To_Unbounded_String ("") then
-                Last := Line;
-            end if;
-        end loop;
+       -- Read the first line from the file
+       Line := Get_Line (F);
 
-        -- Closing the file after playback
-        Close (F);
+       -- Closing the file after playback
+       Close (F);
 
-        -- Processes the last line obtained
-        String_Split.Create
-           (S          => Subs,
-            From       =>
-               To_String
-                  (Last),
-            Separators => Seps,
-            Mode       => String_Split.Multiple);
+       -- Ensure the line is not empty before processing
+       if Line /= To_Unbounded_String ("") then
+           -- Processes the first line obtained
+           String_Split.Create
+              (S    => Subs, From => To_String (Line), Separators => Seps,
+               Mode => String_Split.Multiple);
 
-        -- Converts the value of the third column into a float
-        Value := Long_Float'Value (String_Split.Slice (Subs, 3));
+           -- Converts the value of the third column into a float
+           Value := Long_Float'Value (String_Split.Slice (Subs, 3));
 
-        return Value;
-    exception
-        when others =>
-            Ada.Text_IO.Put_Line
-               ("The file cannot be found, check the path");
-            OS_Exit (0);
-    end Read_File_PowerJoular_Format;
+           return Value;
+       else
+           Ada.Text_IO.Put_Line ("File is empty or first line is blank");
+           OS_Exit (1);
+       end if;
+   exception
+       when others =>
+           Ada.Text_IO.Put_Line
+              ("The file cannot be found, check the path");
+           OS_Exit (0);
+   end Read_File_PowerJoular_Format;
 
    function Read_SingleLine_Format
       (File_Path : String) return Long_Float
@@ -123,7 +119,7 @@ package body Virtual_Machine is
 
         -- Iteration on supported formats
         if VM_Power_Format = ("powerjoular") then
-            Power := Read_File_PowerJoular_Format (VM_File_Name);
+            Power := Read_File_PowerJoular_Format(VM_File_Name);
         elsif VM_Power_Format = ("singleline") then
             Power := Read_SingleLine_Format (VM_File_Name);
         else
@@ -141,5 +137,6 @@ package body Virtual_Machine is
                ("Error: The specified power format is not supported.");
             OS_Exit (0);
     end Read_VM_Power;
+
 
 end Virtual_Machine;

--- a/src/virtual_machine.adb
+++ b/src/virtual_machine.adb
@@ -53,7 +53,7 @@ package body Virtual_Machine is
            OS_Exit (0);
    end Read_File_PowerJoular_Format;
 
-   function Read_SingleLine_Format
+   function Read_Watts_Format
       (File_Path : String) return Long_Float
    is
        F      : File_Type;
@@ -95,7 +95,7 @@ package body Virtual_Machine is
        when E : others =>
            Put_Line ("Error after reading line: " & Exception_Message (E));
            OS_Exit (0);
-   end Read_SingleLine_Format;
+   end Read_Watts_Format;
 
     function Read_VM_Power (File_Name : Unbounded_String; Power_Format : Unbounded_String) return Long_Float is
         VM_File_Name    : String := To_String(File_Name);
@@ -120,8 +120,8 @@ package body Virtual_Machine is
         -- Iteration on supported formats
         if VM_Power_Format = ("powerjoular") then
             Power := Read_File_PowerJoular_Format(VM_File_Name);
-        elsif VM_Power_Format = ("singleline") then
-            Power := Read_SingleLine_Format (VM_File_Name);
+        elsif VM_Power_Format = ("watts") then
+            Power := Read_Watts_Format (VM_File_Name);
         else
             raise Invalid_Format_Exception; -- Format not supported
         end if;

--- a/src/virtual_machine.adb
+++ b/src/virtual_machine.adb
@@ -1,0 +1,145 @@
+with Ada.Strings.Unbounded.Text_IO; use Ada.Strings.Unbounded.Text_IO;
+with Ada.Strings.Unbounded;         use Ada.Strings.Unbounded;
+with Ada.Strings.Fixed;             use Ada.Strings.Fixed;
+with Ada.Strings.Maps;              use Ada.Strings.Maps;
+with Ada.Directories;               use Ada.Directories;
+with Ada.Real_Time;                 use Ada.Real_Time;
+with Ada.Text_IO;                   use Ada.Text_IO;
+with Ada.Strings;                   use Ada.Strings;
+with GNAT.OS_Lib;                   use GNAT.OS_Lib;
+with GNAT.String_Split;             use GNAT;
+with Ada.Exceptions;                use Ada.Exceptions;
+
+package body Virtual_Machine is
+
+    --Read the exported data in PowerJoular format
+    function Read_File_PowerJoular_Format
+       (File_Path : String) return Float
+    is
+        F     : File_Type;
+        Line  : Unbounded_String;
+        Last  : Unbounded_String := To_Unbounded_String ("");
+        Subs  : String_Split.Slice_Set;
+        Seps  : constant String  := ",";
+        Value : Float;
+    begin
+        -- Opens the file in read mode
+        Open (F, In_File, File_Path);
+
+        -- Read all lines to the end of the file to get the last one
+        while not End_Of_File (F) loop
+            Line := Get_Line (F);
+            if Line /= To_Unbounded_String ("") then
+                Last := Line;
+            end if;
+        end loop;
+
+        -- Closing the file after playback
+        Close (F);
+
+        -- Processes the last line obtained
+        String_Split.Create
+           (S          => Subs,
+            From       =>
+               To_String
+                  (Last),
+            Separators => Seps,
+            Mode       => String_Split.Multiple);
+
+        -- Converts the value of the third column into a float
+        Value := Float'Value (String_Split.Slice (Subs, 3));
+
+        return Value;
+    exception
+        when others =>
+            Ada.Text_IO.Put_Line
+               ("The file cannot be found, check the path");
+            OS_Exit (0);
+    end Read_File_PowerJoular_Format;
+
+   function Read_SingleLine_Format
+      (File_Path : String) return Float
+   is
+       F      : File_Type;
+       Line   : Unbounded_String;
+       Result : Float := 0.0;
+   begin
+       Open (F, In_File, File_Path);
+       Line := To_Unbounded_String (Get_Line (F));
+       Close (F);
+
+       -- Clean the string and keep only numbers and dots
+       declare
+           Temp  : String                    := To_String (Line);
+           Clean : String (1 .. Temp'Length) := (others => '0');
+           j     : Natural                   := 1;
+       begin
+           for i in Temp'Range loop
+               if ('0' <= Temp (i) and Temp (i) <= '9') or Temp (i) = '.'
+               then
+                   Clean (j) := Temp (i);
+                   j         := j + 1;
+               end if;
+           end loop;
+           Line := To_Unbounded_String (Clean (1 .. j - 1));
+       end;
+
+       -- Attempted conversion
+       begin
+           Result := Float'Value (To_String (Line));
+       exception
+           when E : others =>
+               Put_Line
+                  ("Failed to convert to float: " & Exception_Message (E));
+               OS_Exit (0);
+       end;
+
+       return Result;
+   exception
+       when E : others =>
+           Put_Line ("Error after reading line: " & Exception_Message (E));
+           OS_Exit (0);
+   end Read_SingleLine_Format;
+
+    function Calculate_VM_Consumption (File_Name : Unbounded_String; Power_Format : Unbounded_String) return Float is
+        VM_File_Name    : String := To_String(File_Name);
+        VM_Power_Format : String := To_String(Power_Format);
+        Power           : Float;
+
+        -- Customized exceptions
+        Invalid_File_Name_Exception : exception;
+        Invalid_Format_Exception    : exception;
+
+    begin
+        -- Check if file name parameter exist
+        if (VM_File_Name) = "" then
+            raise Invalid_File_Name_Exception;
+        end if;
+
+        -- Check file existence
+        if not Exists ((VM_File_Name)) then
+            raise Invalid_File_Name_Exception;
+        end if;
+
+        -- Iteration on supported formats
+        if VM_Power_Format = ("powerjoular") then
+            Power := Read_File_PowerJoular_Format (VM_File_Name);
+        elsif VM_Power_Format = ("singleline") then
+            Power := Read_SingleLine_Format (VM_File_Name);
+        else
+            raise Invalid_Format_Exception; -- Format not supported
+        end if;
+
+        return Power;
+
+    exception
+        when Invalid_File_Name_Exception =>
+            Ada.Text_IO.Put_Line ("Error: The file name is invalid..");
+            OS_Exit (0);
+        when Invalid_Format_Exception    =>
+            Ada.Text_IO.Put_Line
+               ("Error: The specified power format is not supported.");
+            OS_Exit (0);
+    end Calculate_VM_Consumption;
+
+end Virtual_Machine;

--- a/src/virtual_machine.adb
+++ b/src/virtual_machine.adb
@@ -14,14 +14,14 @@ package body Virtual_Machine is
 
     --Read the exported data in PowerJoular format
     function Read_File_PowerJoular_Format
-       (File_Path : String) return Float
+       (File_Path : String) return Long_Float
     is
         F     : File_Type;
         Line  : Unbounded_String;
         Last  : Unbounded_String := To_Unbounded_String ("");
         Subs  : String_Split.Slice_Set;
         Seps  : constant String  := ",";
-        Value : Float;
+        Value : Long_Float;
     begin
         -- Opens the file in read mode
         Open (F, In_File, File_Path);
@@ -47,7 +47,7 @@ package body Virtual_Machine is
             Mode       => String_Split.Multiple);
 
         -- Converts the value of the third column into a float
-        Value := Float'Value (String_Split.Slice (Subs, 3));
+        Value := Long_Float'Value (String_Split.Slice (Subs, 3));
 
         return Value;
     exception
@@ -58,11 +58,11 @@ package body Virtual_Machine is
     end Read_File_PowerJoular_Format;
 
    function Read_SingleLine_Format
-      (File_Path : String) return Float
+      (File_Path : String) return Long_Float
    is
        F      : File_Type;
        Line   : Unbounded_String;
-       Result : Float := 0.0;
+       Result : Long_Float := 0.0;
    begin
        Open (F, In_File, File_Path);
        Line := To_Unbounded_String (Get_Line (F));
@@ -86,11 +86,11 @@ package body Virtual_Machine is
 
        -- Attempted conversion
        begin
-           Result := Float'Value (To_String (Line));
+           Result := Long_Float'Value (To_String (Line));
        exception
            when E : others =>
                Put_Line
-                  ("Failed to convert to float: " & Exception_Message (E));
+                  ("Failed to convert to long float: " & Exception_Message (E));
                OS_Exit (0);
        end;
 
@@ -101,10 +101,10 @@ package body Virtual_Machine is
            OS_Exit (0);
    end Read_SingleLine_Format;
 
-    function Calculate_VM_Consumption (File_Name : Unbounded_String; Power_Format : Unbounded_String) return Float is
+    function Read_VM_Power (File_Name : Unbounded_String; Power_Format : Unbounded_String) return Long_Float is
         VM_File_Name    : String := To_String(File_Name);
         VM_Power_Format : String := To_String(Power_Format);
-        Power           : Float;
+        Power           : Long_Float;
 
         -- Customized exceptions
         Invalid_File_Name_Exception : exception;
@@ -140,6 +140,6 @@ package body Virtual_Machine is
             Ada.Text_IO.Put_Line
                ("Error: The specified power format is not supported.");
             OS_Exit (0);
-    end Calculate_VM_Consumption;
+    end Read_VM_Power;
 
 end Virtual_Machine;

--- a/src/virtual_machine.ads
+++ b/src/virtual_machine.ads
@@ -1,6 +1,6 @@
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 package Virtual_Machine is
 
-   function Calculate_VM_Consumption(File_Name : Unbounded_String; Power_Format : Unbounded_String) return float;
+   function Read_VM_Power(File_Name : Unbounded_String; Power_Format : Unbounded_String) return Long_Float;
 
 end Virtual_Machine;

--- a/src/virtual_machine.ads
+++ b/src/virtual_machine.ads
@@ -1,0 +1,6 @@
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
+package Virtual_Machine is
+
+   function Calculate_VM_Consumption(File_Name : Unbounded_String; Power_Format : Unbounded_String) return float;
+
+end Virtual_Machine;


### PR DESCRIPTION
Added support for consumption monitoring in two different formats. The virtual machine will read a file written in a shared folder between host and guest.


The two formats are “powerjoular” and “watts”.

- powerjoular: powerjoular output format being overwritten
- watts: only the consumption value must be provided