### PR TITLE
Cross compile script

### DIFF
--- a/installer/create-packages-arch-source.sh
+++ b/installer/create-packages-arch-source.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-# Function to check user permissions to write to current directory
+# Function to check user permissions to write to the current directory
 if [ ! -w "$(pwd)" ]; then
     echo "ERROR: You don't have write permission on the directory $(pwd)."
     exit 1
 fi
+
+# List of architectures to cross-compile for
+ARCHS=("x86_64" "aarch64" "armv7h")
 
 # Source directory for PKGBUILD
 PKG_DIR="arch_pkgbuild"
@@ -15,17 +18,50 @@ mkdir -p $PKG_DIR $OUTPUT_DIR
 # Copy the PKGBUILD file to the build directory
 cp PKGBUILD $PKG_DIR/
 
-# Changer de répertoire pour PKGBUILD
+# Change directory to PKGBUILD
 cd $PKG_DIR
 
-# Change directory to PKGBUILD
-makepkg
+# Loop through each architecture and cross-compile
+for ARCH in "${ARCHS[@]}"; do
+    # Set up the environment for cross-compiling
+    case $ARCH in
+        "x86_64")
+            CROSS_COMPILE=""
+            ;;
+        "aarch64")
+            CROSS_COMPILE="aarch64-linux-gnu-"
+            ;;
+        "armv7h")
+            CROSS_COMPILE="arm-linux-gnueabihf-"
+            ;;
+        *)
+            echo "Unsupported architecture: $ARCH"
+            exit 1
+            ;;
+    esac
 
-#  Move the generated package to the output directory
-mv *.pkg.tar.zst ../$OUTPUT_DIR/
+    # Export the necessary environment variables
+    export CC="${CROSS_COMPILE}gcc"
+    export CXX="${CROSS_COMPILE}g++"
+    export AR="${CROSS_COMPILE}ar"
+    export RANLIB="${CROSS_COMPILE}ranlib"
 
-#  Clean up temporary directories
+    # Update PKGBUILD architecture
+    sed -i "s/^arch=.*/arch=('$ARCH')/" PKGBUILD
+
+     # Build the package
+    makepkg -Acfs --noconfirm
+
+    # Move the generated package to the output directory with architecture name
+    mv *.pkg.tar.zst ../$OUTPUT_DIR/powerjoular-$ARCH.pkg.tar.zst
+
+    # Clean up the build directory for the next architecture
+    rm -rf src pkg
+done
+
+# Clean up temporary directories
 cd ..
 rm -rf $PKG_DIR
 
-echo "Arch package has been created and moved to the '$OUTPUT_DIR' directory."
+echo "Arch packages have been created and moved to the '$OUTPUT_DIR' directory."
+

--- a/installer/cross-compile.sh
+++ b/installer/cross-compile.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Cross-Compilation Script for Powerjoular
+set -e  # Exit on any error
+
+# Define architecture specific settings
+declare -A archs=(
+  ["x86_64"]="x86_64-linux-gnu"
+  ["armv7"]="arm-linux-gnueabihf"
+  ["aarch64"]="aarch64-linux-gnu"
+)
+
+# Clean previous builds
+rm -rf build/
+mkdir -p build
+
+# Loop through each architecture
+for arch in "${!archs[@]}"; do
+  target=${archs[$arch]}
+  
+  echo "Building for architecture: $arch, using target: $target..."
+  mkdir -p "build/$arch"
+
+  # Compile using gprbuild for the specific target
+  gprbuild -P../powerjoular.gpr --target=$target --RTS=$target -XTARGET=$target -XBUILD_MODE=release -XLIBRARY_TYPE=relocatable -o "build/$arch/powerjoular"
+
+  echo "Compilation completed for $arch"
+
+  # Here you can add any post-compilation steps, like packaging or additional logging
+done
+
+echo "All builds and packaging completed."


### PR DESCRIPTION
Attempted to fix cross-compilation script by integrating TARGET variable with gprbuild and adjusting environmental paths. 

Changes aim to address issues with gprconfig not finding the Ada toolchain for aarch64-linux-gnu. 

Further adjustments may be needed as the compilation is still not successful on all targets.